### PR TITLE
Hide the language selector if there is only one language

### DIFF
--- a/ps_languageselector.php
+++ b/ps_languageselector.php
@@ -49,6 +49,9 @@ class Ps_Languageselector extends Module implements WidgetInterface
 
     public function renderWidget($hookName = null, array $configuration = [])
     {
+        if (1 >= count(Language::getLanguages(true, $this->context->shop->id))) {
+            return '';
+        }
         $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
         return $this->display(__FILE__, 'ps_languageselector.tpl');
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | dev
| Description?  | Hide the language selector if there is only one language
| Type?         | improvement
| Category?     | MO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1299
| How to test?  | <ul><li>BO: Install at least 2 languages</li><li>FO: You should see the selector</li><li>BO: Remove all the languages except one</li><li>FO: You should not see the selector</li></ul>
