### PR TITLE
Remove cache

### DIFF
--- a/ps_languageselector.php
+++ b/ps_languageselector.php
@@ -56,12 +56,9 @@ class Ps_Languageselector extends Module implements WidgetInterface
         $languages = Language::getLanguages(true, $this->context->shop->id);
 
         if (1 < count($languages)) {
-
-            if (!$this->isCached($this->templateFile, $this->getCacheId('ps_languageselector'))) {
-                $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
-            }
-
-            return $this->fetch($this->templateFile, $this->getCacheId('ps_languageselector'));
+            $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
+            
+            return $this->fetch($this->templateFile);
         }
 
         return false;


### PR DESCRIPTION
Since the languageselector builds his cache only once it will always redirect us to the page where he was used for the first time.

We could either totally remove the cache or build one cache per page.
Here we are removing it :)
Fix http://forge.prestashop.com/browse/BOOM-1822